### PR TITLE
Add gacha game with multiple pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ npm install
 node server.js
 ```
 
-The server serves static files from `public/` and provides these endpoints:
+The server serves static files from `public/` and exposes these endpoints:
 - `POST /roll` : performs a roll and returns the item obtained.
-- `GET /inventory` : returns the list of obtained items.
 - `GET /items` : list of all possible items.
 
-Inventory and items are stored in JSON files under `data/`.
+Inventory is stored locally in the browser via `localStorage`.
+
+Available pages:
+
+- `index.html` - home page
+- `roll.html` - roll for new items
+- `inventory.html` - view your inventory
+- `collection.html` - see all possible items
+- `profile.html` - set your nickname

--- a/data/items.json
+++ b/data/items.json
@@ -1,12 +1,36 @@
 [
-  {"id":1,"name":"Common Sword","description":"A basic sword.","image":"https://via.placeholder.com/100","rarity":"common"},
-  {"id":2,"name":"Common Shield","description":"A basic shield.","image":"https://via.placeholder.com/100","rarity":"common"},
-  {"id":3,"name":"Rare Helmet","description":"A sturdy helmet.","image":"https://via.placeholder.com/100","rarity":"rare"},
-  {"id":4,"name":"Rare Armor","description":"Strong armor.","image":"https://via.placeholder.com/100","rarity":"rare"},
-  {"id":5,"name":"Epic Staff","description":"A magical staff.","image":"https://via.placeholder.com/100","rarity":"epic"},
-  {"id":6,"name":"Epic Bow","description":"A bow of great power.","image":"https://via.placeholder.com/100","rarity":"epic"},
-  {"id":7,"name":"Legendary Dagger","description":"A legendary dagger.","image":"https://via.placeholder.com/100","rarity":"legendary"},
-  {"id":8,"name":"Legendary Armor","description":"Legendary armor.","image":"https://via.placeholder.com/100","rarity":"legendary"},
-  {"id":9,"name":"Ultra-Legendary Crown","description":"Ultimate crown.","image":"https://via.placeholder.com/100","rarity":"ultra-legendary"},
-  {"id":10,"name":"Ultra-Legendary Dragon","description":"A mythical dragon.","image":"https://via.placeholder.com/100","rarity":"ultra-legendary"}
+  {"id":1,"name":"Bronze Sword","description":"A cheap but reliable sword","image":"https://via.placeholder.com/100?text=1","rarity":"common","family":"Knight"},
+  {"id":2,"name":"Wooden Shield","description":"Light shield made of wood","image":"https://via.placeholder.com/100?text=2","rarity":"common","family":"Knight"},
+  {"id":3,"name":"Cloth Armor","description":"Simple armor","image":"https://via.placeholder.com/100?text=3","rarity":"common","family":"Knight"},
+  {"id":4,"name":"Apprentice Wand","description":"Wand for beginners","image":"https://via.placeholder.com/100?text=4","rarity":"common","family":"Wizard"},
+  {"id":5,"name":"Apprentice Robe","description":"Simple robe","image":"https://via.placeholder.com/100?text=5","rarity":"common","family":"Wizard"},
+  {"id":6,"name":"Training Bow","description":"Bow for training","image":"https://via.placeholder.com/100?text=6","rarity":"common","family":"Hunter"},
+  {"id":7,"name":"Leather Quiver","description":"Basic quiver","image":"https://via.placeholder.com/100?text=7","rarity":"common","family":"Hunter"},
+  {"id":8,"name":"Copper Dagger","description":"Small but handy dagger","image":"https://via.placeholder.com/100?text=8","rarity":"common","family":"Assassin"},
+  {"id":9,"name":"Traveler Boots","description":"Comfortable boots","image":"https://via.placeholder.com/100?text=9","rarity":"common","family":"Traveler"},
+  {"id":10,"name":"Rusty Helm","description":"Old helmet","image":"https://via.placeholder.com/100?text=10","rarity":"common","family":"Knight"},
+  {"id":11,"name":"Iron Sword","description":"Standard issue sword","image":"https://via.placeholder.com/100?text=11","rarity":"common","family":"Knight"},
+  {"id":12,"name":"Iron Shield","description":"Standard issue shield","image":"https://via.placeholder.com/100?text=12","rarity":"common","family":"Knight"},
+  {"id":13,"name":"Hunter Cap","description":"Cap for hunters","image":"https://via.placeholder.com/100?text=13","rarity":"common","family":"Hunter"},
+  {"id":14,"name":"Stone Ring","description":"Plain stone ring","image":"https://via.placeholder.com/100?text=14","rarity":"common","family":"Traveler"},
+  {"id":15,"name":"Herbal Potion","description":"Weak healing potion","image":"https://via.placeholder.com/100?text=15","rarity":"common","family":"Alchemist"},
+  {"id":16,"name":"Old Map","description":"Map to unknown places","image":"https://via.placeholder.com/100?text=16","rarity":"common","family":"Traveler"},
+  {"id":17,"name":"Rusty Gauntlet","description":"Gloves made of iron","image":"https://via.placeholder.com/100?text=17","rarity":"common","family":"Knight"},
+  {"id":18,"name":"Simple Amulet","description":"Amulet with small gem","image":"https://via.placeholder.com/100?text=18","rarity":"common","family":"Wizard"},
+
+  {"id":19,"name":"Steel Sword","description":"Better quality sword","image":"https://via.placeholder.com/100?text=19","rarity":"rare","family":"Knight"},
+  {"id":20,"name":"Steel Shield","description":"Better quality shield","image":"https://via.placeholder.com/100?text=20","rarity":"rare","family":"Knight"},
+  {"id":21,"name":"Hunter Bow","description":"Bow with good range","image":"https://via.placeholder.com/100?text=21","rarity":"rare","family":"Hunter"},
+  {"id":22,"name":"Mage Hat","description":"Pointy wizard hat","image":"https://via.placeholder.com/100?text=22","rarity":"rare","family":"Wizard"},
+  {"id":23,"name":"Silver Ring","description":"Ring with silver","image":"https://via.placeholder.com/100?text=23","rarity":"rare","family":"Traveler"},
+  {"id":24,"name":"Healing Potion","description":"Restores health","image":"https://via.placeholder.com/100?text=24","rarity":"rare","family":"Alchemist"},
+  {"id":25,"name":"Assassin Cloak","description":"Light cloak","image":"https://via.placeholder.com/100?text=25","rarity":"rare","family":"Assassin"},
+
+  {"id":26,"name":"Enchanted Sword","description":"Sword with magic","image":"https://via.placeholder.com/100?text=26","rarity":"epic","family":"Knight"},
+  {"id":27,"name":"Phoenix Feather","description":"Rare magical feather","image":"https://via.placeholder.com/100?text=27","rarity":"epic","family":"Wizard"},
+  {"id":28,"name":"Dragon Scale","description":"Tough dragon scale","image":"https://via.placeholder.com/100?text=28","rarity":"epic","family":"Dragon"},
+
+  {"id":29,"name":"Legendary Armor","description":"Armor of legends","image":"https://via.placeholder.com/100?text=29","rarity":"legendary","family":"Knight"},
+
+  {"id":30,"name":"Mythic Dragon","description":"Mythical dragon companion","image":"https://via.placeholder.com/100?text=30","rarity":"mythic","family":"Dragon"}
 ]

--- a/public/collection.html
+++ b/public/collection.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mystic Relics - Home</title>
+  <title>Mystic Relics - Collection</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
@@ -11,16 +11,17 @@
 </head>
 <body>
   <header id="banner">
-    <h1>Mystic Relics</h1>
-  </header>
-  <main id="home">
-    <p>Welcome to Mystic Relics, a simple gacha style collection game. Try your luck and complete the collection!</p>
+    <h1>Collection</h1>
     <nav>
-      <a href="roll.html" class="neon-button">Start Rolling</a>
-      <a href="inventory.html" class="neon-button">Inventory</a>
-      <a href="collection.html" class="neon-button">Collection</a>
-      <a href="profile.html" class="neon-button">Profile</a>
+      <a href="index.html">Home</a>
+      <a href="roll.html">Roll</a>
+      <a href="inventory.html">Inventory</a>
+      <a href="profile.html">Profile</a>
     </nav>
+  </header>
+  <main>
+    <div id="collection" class="inventory-grid"></div>
   </main>
+  <script src="collection.js"></script>
 </body>
 </html>

--- a/public/collection.js
+++ b/public/collection.js
@@ -1,0 +1,15 @@
+async function initCollection() {
+  const res = await fetch('/items');
+  const items = await res.json();
+  const ownedIds = new Set(JSON.parse(localStorage.getItem('inventory') || '[]').map(i=>i.id));
+  const container = document.getElementById('collection');
+  items.forEach(item => {
+    const card = document.createElement('div');
+    card.className = `card ${item.rarity}`;
+    if (!ownedIds.has(item.id)) card.style.filter = 'grayscale(100%)';
+    card.innerHTML = `<img src="${item.image}"><p>${item.name}</p>`;
+    container.appendChild(card);
+  });
+}
+
+initCollection();

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mystic Relics - Inventory</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header id="banner">
+    <h1>Inventory</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="roll.html">Roll</a>
+      <a href="collection.html">Collection</a>
+      <a href="profile.html">Profile</a>
+    </nav>
+  </header>
+  <main>
+    <select id="sort-menu">
+      <option value="">Sort By</option>
+      <option value="name">Name</option>
+      <option value="rarity">Rarity</option>
+      <option value="date">Date</option>
+    </select>
+    <div id="inventory" class="inventory-grid"></div>
+  </main>
+  <script src="roll.js"></script>
+  <script src="inventory.js"></script>
+</body>
+</html>

--- a/public/inventory.js
+++ b/public/inventory.js
@@ -1,0 +1,2 @@
+// reuse logic from roll.js
+init();

--- a/public/profile.html
+++ b/public/profile.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mystic Relics - Home</title>
+  <title>Mystic Relics - Profile</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
@@ -11,16 +11,19 @@
 </head>
 <body>
   <header id="banner">
-    <h1>Mystic Relics</h1>
-  </header>
-  <main id="home">
-    <p>Welcome to Mystic Relics, a simple gacha style collection game. Try your luck and complete the collection!</p>
+    <h1>Profile</h1>
     <nav>
-      <a href="roll.html" class="neon-button">Start Rolling</a>
-      <a href="inventory.html" class="neon-button">Inventory</a>
-      <a href="collection.html" class="neon-button">Collection</a>
-      <a href="profile.html" class="neon-button">Profile</a>
+      <a href="index.html">Home</a>
+      <a href="roll.html">Roll</a>
+      <a href="inventory.html">Inventory</a>
+      <a href="collection.html">Collection</a>
     </nav>
+  </header>
+  <main id="profile">
+    <label>Enter your nickname: <input type="text" id="nickname"></label>
+    <button id="save-nick" class="neon-button">Save</button>
+    <p id="current-nick"></p>
   </main>
+  <script src="profile.js"></script>
 </body>
 </html>

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,0 +1,20 @@
+function loadNickname() {
+  const nick = localStorage.getItem('nickname') || '';
+  const input = document.getElementById('nickname');
+  const display = document.getElementById('current-nick');
+  if (input) input.value = nick;
+  if (display) display.textContent = nick ? `Current nickname: ${nick}` : '';
+}
+
+function saveNickname() {
+  const nick = document.getElementById('nickname').value.trim();
+  if (nick) {
+    localStorage.setItem('nickname', nick);
+    loadNickname();
+  }
+}
+
+const btn = document.getElementById('save-nick');
+if (btn) btn.addEventListener('click', saveNickname);
+
+loadNickname();

--- a/public/roll.html
+++ b/public/roll.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mystic Relics - Roll</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header id="banner">
+    <h1>Mystic Relics</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="inventory.html">Inventory</a>
+      <a href="collection.html">Collection</a>
+      <a href="profile.html">Profile</a>
+    </nav>
+  </header>
+  <main id="app">
+    <button id="roll-btn" class="neon-button">Roll</button>
+    <div id="animation-container"></div>
+    <div id="result"></div>
+    <section id="stats"></section>
+    <h2>Inventory</h2>
+    <select id="sort-menu">
+      <option value="">Sort By</option>
+      <option value="name">Name</option>
+      <option value="rarity">Rarity</option>
+      <option value="date">Date</option>
+    </select>
+    <div id="inventory" class="inventory-grid"></div>
+  </main>
+  <audio id="roll-sound" src="https://actions.google.com/sounds/v1/cartoon/wood_plank_flicks.ogg" preload="auto"></audio>
+  <audio id="rare-sound" src="https://actions.google.com/sounds/v1/cartoon/clang_and_wobble.ogg" preload="auto"></audio>
+  <script src="roll.js"></script>
+</body>
+</html>

--- a/public/roll.js
+++ b/public/roll.js
@@ -36,7 +36,7 @@ async function roll() {
   setTimeout(() => {
     clearInterval(animationInterval);
     showResult(item);
-    loadInventory();
+    addToInventory(item);
     if (['epic','legendary','ultra-legendary'].includes(item.rarity)) {
       playSound('rare-sound');
     }
@@ -44,16 +44,23 @@ async function roll() {
   }, 1500);
 }
 
-document.getElementById('roll-btn').addEventListener('click', roll);
+const rollBtn = document.getElementById('roll-btn');
+if (rollBtn) rollBtn.addEventListener('click', roll);
 
 function showResult(item) {
   const div = document.getElementById('result');
   div.innerHTML = `<div class="card ${item.rarity}"><img src="${item.image}"><p>${item.name}</p></div>`;
 }
 
+function addToInventory(item) {
+  const inv = JSON.parse(localStorage.getItem('inventory') || '[]');
+  inv.push({ ...item, obtainedAt: Date.now() });
+  localStorage.setItem('inventory', JSON.stringify(inv));
+  loadInventory();
+}
+
 async function loadInventory() {
-  const res = await fetch('/inventory');
-  let inv = await res.json();
+  let inv = JSON.parse(localStorage.getItem('inventory') || '[]');
   const sort = document.getElementById('sort-menu').value;
   if (sort === 'name') {
     inv.sort((a,b)=>a.name.localeCompare(b.name));
@@ -74,7 +81,8 @@ async function loadInventory() {
   updateStats(inv);
 }
 
-document.getElementById('sort-menu').addEventListener('change', loadInventory);
+const sortMenu = document.getElementById('sort-menu');
+if (sortMenu) sortMenu.addEventListener('change', loadInventory);
 
 function updateStats(inv) {
   const total = inv.length;

--- a/public/style.css
+++ b/public/style.css
@@ -12,6 +12,14 @@ body {
   padding: 20px 0;
   box-shadow: 0 2px 8px rgba(0,0,0,0.8);
 }
+#banner nav {
+  margin-top: 10px;
+}
+#banner nav a {
+  color: #9a8dff;
+  margin: 0 10px;
+  text-decoration: none;
+}
 #banner h1 {
   font-family: 'Orbitron', sans-serif;
   margin: 0;

--- a/server.js
+++ b/server.js
@@ -10,19 +10,10 @@ app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
 const itemsPath = path.join(__dirname, 'data', 'items.json');
-const inventoryPath = path.join(__dirname, 'data', 'inventory.json');
+const inventoryPath = path.join(__dirname, 'data', 'inventory.json'); // legacy, not used
 
 function loadItems() {
   return JSON.parse(fs.readFileSync(itemsPath));
-}
-
-function loadInventory() {
-  if (!fs.existsSync(inventoryPath)) return [];
-  return JSON.parse(fs.readFileSync(inventoryPath));
-}
-
-function saveInventory(inv) {
-  fs.writeFileSync(inventoryPath, JSON.stringify(inv, null, 2));
 }
 
 const rarityWeights = {
@@ -51,15 +42,9 @@ app.get('/items', (req,res) => {
   res.json(loadItems());
 });
 
-app.get('/inventory', (req,res) => {
-  res.json(loadInventory());
-});
-
 app.post('/roll', (req,res) => {
   const item = rollItem();
-  const inv = loadInventory();
-  inv.push({ ...item, obtainedAt: Date.now() });
-  saveInventory(inv);
+  // inventory is managed on the client via localStorage
   res.json(item);
 });
 


### PR DESCRIPTION
## Summary
- build out simple gacha collection game
- use localStorage for player inventory
- create multiple pages (home, roll, inventory, collection, profile)
- expand item database to 30 items
- update server to only return roll results and item list

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(runs and prints `Server running on port 3000`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c19fd61c833190179fb30afc5051